### PR TITLE
Filter warnings when handled

### DIFF
--- a/src/figwheel/core.cljc
+++ b/src/figwheel/core.cljc
@@ -674,8 +674,6 @@
 
 (defn warnings->warning-infos [warnings]
   (->> warnings
-       (filter
-        (comp cljs.analyzer/*cljs-warnings* :warning-type))
        (map warning-info)
        not-empty))
 
@@ -856,12 +854,13 @@
        (binding [cljs.analyzer/*cljs-warning-handlers*
                  (conj cljs.analyzer/*cljs-warning-handlers*
                        (fn [warning-type env extra]
-                         (vswap! local-data update :warnings
-                                 (fnil conj [])
-                                 {:warning-type warning-type
-                                  :env env
-                                  :extra extra
-                                  :path ana/*cljs-file*})))]
+                         (when (warning-type cljs.analyzer/*cljs-warnings*)
+                           (vswap! local-data update :warnings
+                                   (fnil conj [])
+                                   {:warning-type warning-type
+                                    :env env
+                                    :extra extra
+                                    :path ana/*cljs-file*}))))]
          (try
            (swap! compiler-env vary-meta assoc ::compile-data {:started (System/currentTimeMillis)})
            (let [res (cljs-build src opts compiler-env)]


### PR DESCRIPTION
This PR moves the filtering of warnings to the point where they are handled, rather than letting this occur later.

The reason for this is that the compiler will often analyze forms more than once with warnings suppressed using `cljs.analyzer/no-warn` on all but one pass. With the way the `figwheel.core` code is currently structured, even though the compiler is suppressing its own warnings, the `figwheel.core` handler captures those warnings eagerly, but filters on them later when the scope of the suppressing bindings set up by `cljs.analyzer/no-warn` has been left (and warnings are effectively re-enabled).

To see this, if you add a bit of code to `prn` the `warning-type` argument inside `warning-info/warning-info` and then cause Figwheel to reload code that triggers a warning for code inside a `or` macro

```clojure
(or bogus-var)
```

you will see that `:undeclared-var` will be printed twice.