### PR TITLE
fix problematic :import of goog

### DIFF
--- a/src/figwheel/core.cljc
+++ b/src/figwheel/core.cljc
@@ -23,7 +23,7 @@
         [clojure.tools.reader.reader-types :as rtypes]        
         [figwheel.tools.exceptions :as fig-ex]]))
   #?(:cljs (:require-macros [figwheel.core]))
-  (:import #?@(:cljs [[goog]
+  (:import #?@(:cljs [goog
                       [goog.debug Console]
                       [goog.async Deferred]
                       [goog Promise]


### PR DESCRIPTION
As statet in https://github.com/bhauman/figwheel-core/issues/1#issue-378664807
there is a problem in using figwheel.main on newer cljs versions >= 1.10.439.

After code change and reloading in browser this error appears
`"WARNING: preload namespace figwheel.core does not exist" `

As you statet in https://clojurians-log.clojureverse.org/figwheel-main/2018-12-01/1543673931.003100
 js/figwheel.core probably is getting deleted after every recompile.

Finally the following warning gives hint for the root cause
```
[Figwheel:WARNING] Could not Compile: Call to cljs.core/ns-special-form did not conform to spec.  target/public/cljs-out/dev/figwheel/core.cljc   
[Figwheel:SEVERE] clojure.lang.ExceptionInfo: Call to cljs.core/ns-special-form did not conform to spec.
```


This fix does not interfere with cljs versions < 1.10.439