### PR TITLE
Add :paths entry to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,3 @@
-{:deps {org.clojure/clojure       {:mvn/version "1.8.0"}
+{:paths ["src"]
+ :deps {org.clojure/clojure       {:mvn/version "1.8.0"}
         org.clojure/clojurescript {:mvn/version "1.10.238"}}}


### PR DESCRIPTION
Without this, using this as a git dep does not necessarily work, e. g. if "src" is not one of the users projects :path s