### PR TITLE
Catch errors that are thrown in hooks

### DIFF
--- a/src/figwheel/core.cljc
+++ b/src/figwheel/core.cljc
@@ -260,7 +260,9 @@
                             (map str (concat (string/split n #"\.") [f])))]
         (do
           (glog/info logger (str "Calling " (pr-str hook-key) " hook - " n "." f))
-          (apply hook args))
+          (try
+            (apply hook args)
+            (catch js/Error e nil)))
         (glog/warning logger (str "Unable to find " (pr-str hook-key) " hook - " n "." f))))))
 
 (defn ^:export reload-namespaces [namespaces figwheel-meta]


### PR DESCRIPTION
This fixes an issue with needing to click refresh on the browser after an ^:after-load function throws an exception.
I've described the issue in https://github.com/komcrad/figwheel-example

Maybe this should be fixed in documentation to avoid messing up someone's setup. (In case someone wants their reload function to throw errors)

Maybe I need to provide a way to allow hooks to throw or swallow errors to avoid breaking backwards compatibility.

This is the smallest change I came up with. Open for discussion.